### PR TITLE
Fix search term for Jenkins plugin manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This setup assumes that you already have an AWS account and that you're able to 
 ###Install the plugin on Jenkins
 
 1. Go to `Jenkins > Manage Jenkins > Manage Plugins`.
-2. Go to `Available` and search for `scm sqs`.
+2. Go to `Available` and search for `scm-sqs` or `aws sqs`.
 3. Install the plugin and restart your Jenkins.
 
 If you've built the plugin from source go to `Advanced` and upload the plugin manually. Don't forget to check the plugin's Wiki page on Jenkins-CI.org: https://wiki.jenkins-ci.org/display/JENKINS/SCM+SQS+Plugin.


### PR DESCRIPTION
Fix the search term in the readme file. User needs to type `scm-sqs` instead of `scm sqs` to find the plugin.