### PR TITLE
Fix duplicate monitor instance and related issues

### DIFF
--- a/src/main/java/io/relution/jenkins/scmsqs/Context.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/Context.java
@@ -46,7 +46,7 @@ public class Context extends com.google.inject.AbstractModule {
 
     private static Injector injector;
 
-    public static Injector injector() {
+    public synchronized static Injector injector() {
         if (injector == null) {
             injector = Guice.createInjector(new Context());
         }

--- a/src/main/java/io/relution/jenkins/scmsqs/Context.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/Context.java
@@ -22,7 +22,6 @@ import com.google.inject.Injector;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
-import hudson.Extension;
 import io.relution.jenkins.scmsqs.factories.ExecutorFactoryImpl;
 import io.relution.jenkins.scmsqs.factories.MessageParserFactoryImpl;
 import io.relution.jenkins.scmsqs.factories.SQSFactoryImpl;
@@ -42,7 +41,6 @@ import io.relution.jenkins.scmsqs.threading.ExecutorProviderImpl;
 import io.relution.jenkins.scmsqs.threading.SQSQueueMonitorSchedulerImpl;
 
 
-@Extension
 public class Context extends com.google.inject.AbstractModule {
 
     private static Injector injector;

--- a/src/main/java/io/relution/jenkins/scmsqs/Context.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/Context.java
@@ -35,6 +35,7 @@ import io.relution.jenkins.scmsqs.interfaces.SQSFactory;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitorScheduler;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueProvider;
 import io.relution.jenkins.scmsqs.model.EventTriggerMatcherImpl;
+import io.relution.jenkins.scmsqs.model.SQSQueueProviderImpl;
 import io.relution.jenkins.scmsqs.net.RequestFactory;
 import io.relution.jenkins.scmsqs.net.RequestFactoryImpl;
 import io.relution.jenkins.scmsqs.threading.ExecutorProviderImpl;
@@ -80,7 +81,7 @@ public class Context extends com.google.inject.AbstractModule {
                 .in(com.google.inject.Singleton.class);
 
         this.bind(SQSQueueProvider.class)
-                .to(SQSTrigger.DescriptorImpl.class)
+                .to(SQSQueueProviderImpl.class)
                 .in(com.google.inject.Singleton.class);
 
         this.bind(SQSQueueMonitorScheduler.class)

--- a/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
@@ -224,6 +224,8 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         private volatile transient Map<String, SQSTriggerQueue> sqsQueueMap;
         private volatile transient SQSQueueMonitorScheduler     scheduler;
 
+        private transient boolean                               isLoaded;
+
         public static DescriptorImpl get() {
             final DescriptorExtensionList<Trigger<?>, TriggerDescriptor> triggers = Trigger.all();
             return triggers.get(DescriptorImpl.class);
@@ -237,6 +239,7 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         public synchronized void load() {
             super.load();
             this.initQueueMap();
+            this.isLoaded = true;
         }
 
         @Override
@@ -291,7 +294,7 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         }
 
         public List<SQSTriggerQueue> getSqsQueues() {
-            if (this.sqsQueues == null) {
+            if (!this.isLoaded) {
                 this.load();
             }
             if (this.sqsQueues == null) {
@@ -301,6 +304,9 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         }
 
         public SQSQueue getSqsQueue(final String uuid) {
+            if (!this.isLoaded) {
+                this.load();
+            }
             if (this.sqsQueueMap == null) {
                 return null;
             }

--- a/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
@@ -175,7 +175,7 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         final EventTriggerMatcher matcher = this.getEventTriggerMatcher();
         final List<Event> events = parser.parseMessage(message);
 
-        if (matcher.matches(events, this.job.getScm())) {
+        if (matcher.matches(events, this.job)) {
             this.execute();
         }
     }

--- a/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
@@ -57,6 +57,7 @@ import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitorScheduler;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueProvider;
 import io.relution.jenkins.scmsqs.logging.Log;
+import jenkins.model.Jenkins;
 
 
 public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQueueListener, Runnable {
@@ -73,6 +74,11 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
     @DataBoundConstructor
     public SQSTrigger(final String queueUuid) {
         this.queueUuid = queueUuid;
+    }
+
+    @Override
+    public TriggerDescriptor getDescriptor() {
+        return (TriggerDescriptor) Jenkins.getInstance().getDescriptorOrDie(this.getClass());
     }
 
     public File getLogFile() {

--- a/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
+import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.Util;
 import hudson.console.AnnotatedLargeText;
@@ -224,7 +225,8 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         private volatile transient SQSQueueMonitorScheduler     scheduler;
 
         public static DescriptorImpl get() {
-            return Trigger.all().get(DescriptorImpl.class);
+            final DescriptorExtensionList<Trigger<?>, TriggerDescriptor> triggers = Trigger.all();
+            return triggers.get(DescriptorImpl.class);
         }
 
         public DescriptorImpl() {

--- a/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
@@ -55,7 +55,6 @@ import io.relution.jenkins.scmsqs.interfaces.MessageParserFactory;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitorScheduler;
-import io.relution.jenkins.scmsqs.interfaces.SQSQueueProvider;
 import io.relution.jenkins.scmsqs.logging.Log;
 import jenkins.model.Jenkins;
 
@@ -222,7 +221,7 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
     }
 
     @Extension
-    public static class DescriptorImpl extends TriggerDescriptor implements SQSQueueProvider {
+    public static final class DescriptorImpl extends TriggerDescriptor {
 
         private static final String                             KEY_SQS_QUEUES = "sqsQueues";
         private volatile List<SQSTriggerQueue>                  sqsQueues;
@@ -295,7 +294,6 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
             return true;
         }
 
-        @Override
         public List<SQSTriggerQueue> getSqsQueues() {
             if (this.sqsQueues == null) {
                 this.load();
@@ -306,7 +304,6 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
             return this.sqsQueues;
         }
 
-        @Override
         public SQSQueue getSqsQueue(final String uuid) {
             if (this.sqsQueueMap == null) {
                 return null;

--- a/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/SQSTrigger.java
@@ -56,7 +56,6 @@ import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitorScheduler;
 import io.relution.jenkins.scmsqs.logging.Log;
-import jenkins.model.Jenkins;
 
 
 public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQueueListener, Runnable {
@@ -73,11 +72,6 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
     @DataBoundConstructor
     public SQSTrigger(final String queueUuid) {
         this.queueUuid = queueUuid;
-    }
-
-    @Override
-    public TriggerDescriptor getDescriptor() {
-        return (TriggerDescriptor) Jenkins.getInstance().getDescriptorOrDie(this.getClass());
     }
 
     public File getLogFile() {
@@ -234,7 +228,7 @@ public class SQSTrigger extends Trigger<AbstractProject<?, ?>> implements SQSQue
         }
 
         public DescriptorImpl() {
-            this.load();
+            super(SQSTrigger.class);
         }
 
         @Override

--- a/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
@@ -86,6 +86,12 @@ public class SQSFactoryImpl implements SQSFactory {
         return new SQSQueueMonitorImpl(executor, queue, channel);
     }
 
+    @Override
+    public SQSQueueMonitor createMonitor(final SQSQueueMonitor monitor, final SQSQueue queue) {
+        final SQSChannel channel = this.createChannel(queue);
+        return monitor.clone(queue, channel);
+    }
+
     private ClientConfiguration getClientConfiguration(final SQSQueue queue) {
         final ClientConfiguration config = new ClientConfiguration();
 

--- a/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
@@ -83,7 +83,7 @@ public class SQSFactoryImpl implements SQSFactory {
     @Override
     public SQSQueueMonitor createMonitor(final ExecutorService executor, final SQSQueue queue) {
         final SQSChannel channel = this.createChannel(queue);
-        return new SQSQueueMonitorImpl(executor, channel);
+        return new SQSQueueMonitorImpl(executor, queue, channel);
     }
 
     private ClientConfiguration getClientConfiguration(final SQSQueue queue) {

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/EventTriggerMatcher.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/EventTriggerMatcher.java
@@ -18,32 +18,21 @@ package io.relution.jenkins.scmsqs.interfaces;
 
 import java.util.List;
 
-import hudson.scm.SCM;
+import hudson.model.AbstractProject;
 
 
 /**
- * Interface definition for classes that match events to source code management (SCM)
- * configurations.
+ * Interface definition for classes that match events to {@link AbstractProject}s. If an event
+ * matches a project its build process should be triggered.
  */
 public interface EventTriggerMatcher {
 
     /**
-     * Returns a value indicating whether any of the specified events matches the specified SCM
-     * configuration.
-     * @param events The collection of {@link Event}s to test against the SCM configuration.
-     * @param scm The {@link SCM} to test against.
-     * @return {@code true} if any of the specified events matches the specified SCM configuration;
-     * otherwise, {@code false}.
+     * Returns a value indicating whether any of the specified events matches the specified job.
+     * @param events The collection of {@link Event}s to test against the job.
+     * @param job The {@link AbstractProject} to test against.
+     * @return {@code true} if any of the specified events matches the specified job; otherwise,
+     * {@code false}.
      */
-    boolean matches(List<Event> events, SCM scm);
-
-    /**
-     * Returns a value indicating whether the specified event matches the specified SCM
-     * configuration.
-     * @param event The {@link Event} to test against the SCM configuration.
-     * @param scm The {@link SCM} to test against.
-     * @return {@code true} if the specified event matches the specified SCM configuration;
-     * otherwise, {@code false}.
-     */
-    boolean matches(Event event, SCM scm);
+    boolean matches(List<Event> events, AbstractProject<?, ?> job);
 }

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSFactory.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSFactory.java
@@ -62,4 +62,17 @@ public interface SQSFactory {
      * @return A new {@link SQSQueueMonitor} instance suitable for monitoring the specified queue.
      */
     SQSQueueMonitor createMonitor(final ExecutorService executor, final SQSQueue queue);
+
+    /**
+     * Returns a new monitor instance that can be used to poll the specified queue for new
+     * messages.
+     * <p>
+     * The new monitor has the same listeners as the specified monitor. This should be used to
+     * create a new monitor instance in case a queue was reconfigured.
+     * @param monitor The monitor used to initialize internal fields of the new instance.
+     * @param queue The {@link SQSQueue} for which to create a monitor.
+     * @return A new {@link SQSQueueMonitor} instance suitable for monitoring the specified queue,
+     * that has the same listeners as the specified monitor.
+     */
+    SQSQueueMonitor createMonitor(final SQSQueueMonitor monitor, final SQSQueue queue);
 }

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitor.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitor.java
@@ -18,6 +18,8 @@ package io.relution.jenkins.scmsqs.interfaces;
 
 import com.amazonaws.services.sqs.model.Message;
 
+import io.relution.jenkins.scmsqs.net.SQSChannel;
+
 
 /**
  * Interface definition for classes that can be used to monitor an Amazon {@link SQSQueue} for new
@@ -63,4 +65,16 @@ public interface SQSQueueMonitor extends Runnable {
      * @return {@code true} if the monitor is stopped; otherwise, {@code false}.
      */
     boolean isShutDown();
+
+    /**
+     * Returns the SQS queue this monitor is associated with.
+     * @return The {@link SQSQueue} this monitor is associated with.
+     */
+    SQSQueue getQueue();
+
+    /**
+     * Returns the SQS channel this monitor is associated with.
+     * @return The {@link SQSChannel} this monitor is associated with.
+     */
+    SQSChannel getChannel();
 }

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitor.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitor.java
@@ -28,6 +28,15 @@ import io.relution.jenkins.scmsqs.net.SQSChannel;
 public interface SQSQueueMonitor extends Runnable {
 
     /**
+     * Returns a new instance for the specified queue and channel that has the same listeners as
+     * this instance.
+     * @param queue The {@link SQSQueue} to monitor.
+     * @param channel The {@link SQSChannel} used to access the queue.
+     * @return A new {@link SQSQueueMonitor} instance.
+     */
+    SQSQueueMonitor clone(SQSQueue queue, SQSChannel channel);
+
+    /**
      * Registers a new listener with the monitor. The listener is notified when new messages arrive
      * in the queue.
      * <p>

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitorScheduler.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitorScheduler.java
@@ -16,6 +16,11 @@
 
 package io.relution.jenkins.scmsqs.interfaces;
 
+import com.google.common.eventbus.Subscribe;
+
+import io.relution.jenkins.scmsqs.model.events.ConfigurationChangedEvent;
+
+
 /**
  * Interface definition for classes that schedule the execution of {@link SQSQueueMonitor}
  * instances.
@@ -48,5 +53,6 @@ public interface SQSQueueMonitorScheduler {
      * Notifies the scheduler that the global configuration was changed. It should shut down all
      * monitors for which the associated queue configuration was removed.
      */
-    void onConfigurationChanged();
+    @Subscribe
+    void onConfigurationChanged(ConfigurationChangedEvent event);
 }

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitorScheduler.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSQueueMonitorScheduler.java
@@ -52,6 +52,7 @@ public interface SQSQueueMonitorScheduler {
     /**
      * Notifies the scheduler that the global configuration was changed. It should shut down all
      * monitors for which the associated queue configuration was removed.
+     * @param event The configuration changed event.
      */
     @Subscribe
     void onConfigurationChanged(ConfigurationChangedEvent event);

--- a/src/main/java/io/relution/jenkins/scmsqs/model/EventTriggerMatcherImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/model/EventTriggerMatcherImpl.java
@@ -22,33 +22,38 @@ import org.jenkinsci.plugins.multiplescms.MultiSCM;
 
 import java.util.List;
 
+import hudson.model.AbstractProject;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 import io.relution.jenkins.scmsqs.interfaces.Event;
 import io.relution.jenkins.scmsqs.interfaces.EventTriggerMatcher;
+import io.relution.jenkins.scmsqs.logging.Log;
 import jenkins.model.Jenkins;
 
 
 public class EventTriggerMatcherImpl implements EventTriggerMatcher {
 
     @Override
-    public boolean matches(final List<Event> events, final SCM scm) {
-        if (events == null || scm == null) {
+    public boolean matches(final List<Event> events, final AbstractProject<?, ?> job) {
+        if (events == null || job == null) {
             return false;
         }
 
+        Log.info("Test if any event matches job %s", job.getName());
+
         for (final Event event : events) {
-            if (this.matches(event, scm)) {
+            if (this.matches(event, job.getScm())) {
+                Log.info("Job %s matches event %s%s (%s)", job.getName(), event.getHost(), event.getPath(), event.getBranch());
                 return true;
             }
         }
 
+        Log.info("Event(s) did not match job.");
         return false;
     }
 
-    @Override
-    public boolean matches(final Event event, final SCM scm) {
+    private boolean matches(final Event event, final SCM scm) {
         if (event == null || scm == null) {
             return false;
         }

--- a/src/main/java/io/relution/jenkins/scmsqs/model/SQSQueueProviderImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/model/SQSQueueProviderImpl.java
@@ -1,0 +1,24 @@
+
+package io.relution.jenkins.scmsqs.model;
+
+import java.util.List;
+
+import io.relution.jenkins.scmsqs.SQSTrigger;
+import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
+import io.relution.jenkins.scmsqs.interfaces.SQSQueueProvider;
+
+
+public class SQSQueueProviderImpl implements SQSQueueProvider {
+
+    @Override
+    public List<? extends SQSQueue> getSqsQueues() {
+        final SQSTrigger.DescriptorImpl descriptor = SQSTrigger.DescriptorImpl.get();
+        return descriptor.getSqsQueues();
+    }
+
+    @Override
+    public SQSQueue getSqsQueue(final String uuid) {
+        final SQSTrigger.DescriptorImpl descriptor = SQSTrigger.DescriptorImpl.get();
+        return descriptor.getSqsQueue(uuid);
+    }
+}

--- a/src/main/java/io/relution/jenkins/scmsqs/model/constants/ErrorCode.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/model/constants/ErrorCode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.relution.jenkins.scmsqs.model.constants;
+
+/**
+ * Defines constants for error codes returned by Amazon Web Services (AWS).
+ */
+public final class ErrorCode {
+
+    /**
+     * The X.509 certificate or AWS access key ID provided does not exist on AWS.
+     * <p>
+     * HTTP Status Code: 403
+     */
+    public static final String INVALID_CLIENT_TOKEN_ID = "InvalidClientTokenId";
+
+    private ErrorCode() {
+    }
+}

--- a/src/main/java/io/relution/jenkins/scmsqs/model/events/ConfigurationChangedEvent.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/model/events/ConfigurationChangedEvent.java
@@ -1,0 +1,10 @@
+
+package io.relution.jenkins.scmsqs.model.events;
+
+import io.relution.jenkins.scmsqs.SQSTrigger;
+
+
+/**
+ * Event that is sent by the {@link SQSTrigger.DescriptorImpl} when its configuration is changed.
+ */
+public class ConfigurationChangedEvent {}

--- a/src/main/java/io/relution/jenkins/scmsqs/model/events/EventBroker.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/model/events/EventBroker.java
@@ -1,0 +1,51 @@
+
+package io.relution.jenkins.scmsqs.model.events;
+
+import com.google.common.eventbus.EventBus;
+
+
+/**
+ * Provides a single instance of {@link EventBus}.
+ */
+public class EventBroker {
+
+    private static EventBroker instance;
+
+    private final EventBus     eventBus = new EventBus();
+
+    public synchronized static EventBroker getInstance() {
+        if (instance == null) {
+            instance = new EventBroker();
+        }
+        return instance;
+    }
+
+    /**
+     * Registers all handler methods on {@code object} to receive events.
+     * @param object The object whose handler methods should be registered.
+     * @see EventBus#register(Object)
+     */
+    public void register(final Object object) {
+        this.eventBus.register(object);
+    }
+
+    /**
+     * Unregisters all handler methods on a registered object.
+     * @param object The object whose handler methods should be unregistered.
+     * @throws IllegalArgumentException if the object was not previously registered.
+     * @see EventBus#unregister(Object)
+     */
+    public void unregister(final Object object) {
+        this.eventBus.unregister(object);
+    }
+
+    /**
+     * Posts an event to all registered handlers. This method will return successfully after the
+     * event has been posted to all handlers, and regardless of any exceptions thrown by handlers.
+     * @param event The event to post
+     * @see EventBus#post(Object)
+     */
+    public void post(final Object event) {
+        this.eventBus.post(event);
+    }
+}

--- a/src/main/java/io/relution/jenkins/scmsqs/net/RequestFactoryImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/net/RequestFactoryImpl.java
@@ -19,7 +19,6 @@ public class RequestFactoryImpl implements RequestFactory {
         final ReceiveMessageRequest request = new ReceiveMessageRequest(queue.getUrl());
         request.setMaxNumberOfMessages(queue.getMaxNumberOfMessages());
         request.setWaitTimeSeconds(queue.getWaitTimeSeconds());
-        request.setRequestCredentials(queue);
         return request;
     }
 
@@ -33,7 +32,6 @@ public class RequestFactoryImpl implements RequestFactory {
         }
 
         final DeleteMessageBatchRequest request = new DeleteMessageBatchRequest(queue.getUrl());
-        request.setRequestCredentials(queue);
         request.setEntries(entries);
         return request;
     }

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
@@ -72,7 +72,6 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
         this.channel = channel;
 
         this.listeners = listeners;
-        this.isShutDown = isShutDown;
     }
 
     @Override

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
@@ -101,6 +101,10 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
             Log.warning("Queue %s does not exist, monitor stopped", this.channel);
             this.isShutDown = true;
 
+        } catch (final com.amazonaws.AmazonServiceException e) {
+            Log.warning("Service error for queue %s, monitor stopped", this.channel);
+            this.isShutDown = true;
+
         } catch (final Exception e) {
             Log.severe(e, "Unknown error, monitor for queue %s stopped", this.channel);
             this.isShutDown = true;

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
@@ -41,7 +41,7 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
     private final SQSChannel             channel;
 
     private final Object                 listenersLock     = new Object();
-    private final List<SQSQueueListener> listeners         = new ArrayList<>();
+    private final List<SQSQueueListener> listeners;
 
     private final AtomicBoolean          isRunning         = new AtomicBoolean();
     private volatile boolean             isShutDown;
@@ -54,6 +54,32 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
 
         this.queue = queue;
         this.channel = channel;
+
+        this.listeners = new ArrayList<>();
+    }
+
+    private SQSQueueMonitorImpl(final ExecutorService executor,
+            final SQSQueue queue,
+            final SQSChannel channel,
+            final List<SQSQueueListener> listeners,
+            final boolean isShutDown) {
+        ThrowIf.isNull(executor, "executor");
+        ThrowIf.isNull(channel, "channel");
+
+        this.executor = executor;
+
+        this.queue = queue;
+        this.channel = channel;
+
+        this.listeners = listeners;
+        this.isShutDown = isShutDown;
+    }
+
+    @Override
+    public SQSQueueMonitor clone(final SQSQueue queue, final SQSChannel channel) {
+        synchronized (this.listenersLock) {
+            return new SQSQueueMonitorImpl(this.executor, queue, channel, this.listeners, this.isShutDown);
+        }
     }
 
     @Override

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitor;
 import io.relution.jenkins.scmsqs.logging.Log;
@@ -35,6 +36,8 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
     private final static String          ERROR_WRONG_QUEUE = "The specified listener is associated with another queue.";
 
     private final ExecutorService        executor;
+
+    private final SQSQueue               queue;
     private final SQSChannel             channel;
 
     private final Object                 listenersLock     = new Object();
@@ -43,11 +46,13 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
     private final AtomicBoolean          isRunning         = new AtomicBoolean();
     private volatile boolean             isShutDown;
 
-    public SQSQueueMonitorImpl(final ExecutorService executor, final SQSChannel channel) {
+    public SQSQueueMonitorImpl(final ExecutorService executor, final SQSQueue queue, final SQSChannel channel) {
         ThrowIf.isNull(executor, "executor");
         ThrowIf.isNull(channel, "channel");
 
         this.executor = executor;
+
+        this.queue = queue;
         this.channel = channel;
     }
 
@@ -125,6 +130,16 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
     @Override
     public boolean isShutDown() {
         return this.isShutDown;
+    }
+
+    @Override
+    public SQSQueue getQueue() {
+        return this.queue;
+    }
+
+    @Override
+    public SQSChannel getChannel() {
+        return this.channel;
     }
 
     private void execute() {

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
@@ -147,28 +147,35 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
     }
 
     private boolean hasQueueChanged(final SQSQueueMonitor monitor, final SQSQueue queue) {
-        final SQSQueue current = monitor.getQueue();
+        try {
+            final SQSQueue current = monitor.getQueue();
 
-        if (!StringUtils.equals(current.getUrl(), queue.getUrl())) {
-            return true;
+            if (!StringUtils.equals(current.getUrl(), queue.getUrl())) {
+                return true;
+            }
+
+            if (!StringUtils.equals(current.getAWSAccessKeyId(), queue.getAWSAccessKeyId())) {
+                return true;
+            }
+
+            if (!StringUtils.equals(current.getAWSSecretKey(), queue.getAWSSecretKey())) {
+                return true;
+            }
+
+            if (current.getMaxNumberOfMessages() != queue.getMaxNumberOfMessages()) {
+                return true;
+            }
+
+            if (current.getWaitTimeSeconds() != queue.getWaitTimeSeconds()) {
+                return true;
+            }
+
+            return false;
+        } catch (final com.amazonaws.AmazonServiceException e) {
+            Log.warning("Cannot compare queues: %s", e.getMessage());
+        } catch (final Exception e) {
+            Log.severe(e, "Cannot compare queues, unknown error");
         }
-
-        if (!StringUtils.equals(current.getAWSAccessKeyId(), queue.getAWSAccessKeyId())) {
-            return true;
-        }
-
-        if (!StringUtils.equals(current.getAWSSecretKey(), queue.getAWSSecretKey())) {
-            return true;
-        }
-
-        if (current.getMaxNumberOfMessages() != queue.getMaxNumberOfMessages()) {
-            return true;
-        }
-
-        if (current.getWaitTimeSeconds() != queue.getWaitTimeSeconds()) {
-            return true;
-        }
-
-        return false;
+        return true;
     }
 }

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
@@ -134,14 +134,10 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
             Log.info("Queue {%s} removed, shut down monitor", uuid);
             monitor.shutDown();
             entries.remove();
-        } else if (this.hasQueueChanged(monitor, queue)) {
-            Log.info("Queue {%s} changed, create new monitor", uuid);
+        } else if (monitor.isShutDown() || this.hasQueueChanged(monitor, queue)) {
+            Log.info("Queue {%s} changed or monitor stopped, create new monitor", uuid);
             monitor = this.factory.createMonitor(monitor, queue);
             entry.setValue(monitor).shutDown();
-        }
-
-        if (queue != null && monitor.isShutDown()) {
-            Log.info("Monitor for queue {%s} is shut down, restart", uuid);
             this.executor.execute(monitor);
         }
     }

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
@@ -16,6 +16,7 @@
 
 package io.relution.jenkins.scmsqs.threading;
 
+import com.google.common.eventbus.Subscribe;
 import com.google.inject.Inject;
 
 import java.util.HashMap;
@@ -31,6 +32,8 @@ import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitor;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitorScheduler;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueProvider;
 import io.relution.jenkins.scmsqs.logging.Log;
+import io.relution.jenkins.scmsqs.model.events.ConfigurationChangedEvent;
+import io.relution.jenkins.scmsqs.model.events.EventBroker;
 import io.relution.jenkins.scmsqs.util.ThrowIf;
 
 
@@ -47,6 +50,8 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
         this.executor = executor;
         this.provider = provider;
         this.factory = factory;
+
+        EventBroker.getInstance().register(this);
     }
 
     @Override
@@ -94,8 +99,8 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
         return true;
     }
 
-    @Override
-    public synchronized void onConfigurationChanged() {
+    @Subscribe
+    public synchronized void onConfigurationChanged(final ConfigurationChangedEvent event) {
         final Iterator<Entry<String, SQSQueueMonitor>> entries = this.monitors.entrySet().iterator();
 
         while (entries.hasNext()) {

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImpl.java
@@ -67,7 +67,7 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
     }
 
     @Override
-    public boolean unregister(final SQSQueueListener listener) {
+    public synchronized boolean unregister(final SQSQueueListener listener) {
         if (listener == null) {
             return false;
         }
@@ -95,7 +95,7 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
     }
 
     @Override
-    public void onConfigurationChanged() {
+    public synchronized void onConfigurationChanged() {
         final Iterator<Entry<String, SQSQueueMonitor>> entries = this.monitors.entrySet().iterator();
 
         while (entries.hasNext()) {
@@ -104,7 +104,7 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
         }
     }
 
-    private void register(final SQSQueueListener listener, final String uuid, final SQSQueue queue) {
+    private synchronized void register(final SQSQueueListener listener, final String uuid, final SQSQueue queue) {
         SQSQueueMonitor monitor = this.monitors.get(uuid);
 
         if (monitor == null) {

--- a/src/main/java/io/relution/jenkins/scmsqs/util/ErrorType.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/util/ErrorType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.relution.jenkins.scmsqs.util;
+
+import com.amazonaws.AmazonServiceException;
+
+import org.apache.commons.lang3.StringUtils;
+
+
+/**
+ * Provides static methods that can be used to filter exceptions based on their properties.
+ */
+public class ErrorType {
+
+    /**
+     * Returns a value indicating whether the specified service exception has the specified error
+     * code and HTTP status.
+     * @param e The {@link AmazonServiceException} to test.
+     * @param errorCode The error code to match, can be {@code null}.
+     * @param httpStatus The HTTP status to match. Use {@code -1} to match any HTTP status.
+     * @return {@code true} if the specified exception has the specified error code and HTTP status;
+     * otherwise, {@code false}.
+     */
+    public static boolean is(final AmazonServiceException e, final String errorCode, final int httpStatus) {
+        if (e == null) {
+            return false;
+        }
+
+        if (errorCode != null && !StringUtils.equals(errorCode, e.getErrorCode())) {
+            return false;
+        }
+
+        if (httpStatus != -1 && e.getStatusCode() != httpStatus) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitor;
 import io.relution.jenkins.scmsqs.net.SQSChannel;
@@ -45,6 +46,9 @@ public class SQSQueueMonitorImplTest {
 
     @Mock
     private ExecutorService     executor;
+
+    @Mock
+    private SQSQueue            queue;
 
     @Mock
     private SQSChannel          channel;
@@ -68,7 +72,7 @@ public class SQSQueueMonitorImplTest {
         Mockito.when(this.listener.getQueueUuid()).thenReturn(UUID_A);
         Mockito.when(this.channel.getQueueUuid()).thenReturn(UUID_A);
 
-        this.monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+        this.monitor = new SQSQueueMonitorImpl(this.executor, this.queue, this.channel);
     }
 
     @Test

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImplTest.java
@@ -284,8 +284,8 @@ public class SQSQueueMonitorSchedulerImplTest {
         Mockito.verify(this.factory).createMonitor(this.monitorA, queueA_);
         Mockito.verify(this.monitorA).getQueue();
         Mockito.verify(this.monitorA).shutDown();
+        Mockito.verify(this.monitorA).isShutDown();
         Mockito.verifyNoMoreInteractions(this.monitorA);
-        Mockito.verify(monitorA_).isShutDown();
         Mockito.verifyNoMoreInteractions(monitorA_);
     }
 

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorSchedulerImplTest.java
@@ -35,6 +35,7 @@ import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitor;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitorScheduler;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueProvider;
+import io.relution.jenkins.scmsqs.model.events.ConfigurationChangedEvent;
 
 
 public class SQSQueueMonitorSchedulerImplTest {
@@ -238,7 +239,7 @@ public class SQSQueueMonitorSchedulerImplTest {
         Mockito.verify(this.monitorA, times(1)).add(this.listenerA1);
         Mockito.verify(this.monitorB, times(1)).add(this.listenerB1);
 
-        this.scheduler.onConfigurationChanged();
+        this.scheduler.onConfigurationChanged(new ConfigurationChangedEvent());
 
         Mockito.verifyNoMoreInteractions(this.factory);
         Mockito.verify(this.monitorA).isShutDown();
@@ -257,7 +258,7 @@ public class SQSQueueMonitorSchedulerImplTest {
         Mockito.verify(this.monitorB, times(1)).add(this.listenerB1);
         Mockito.when(this.provider.getSqsQueue(UUID_B)).thenReturn(null);
 
-        this.scheduler.onConfigurationChanged();
+        this.scheduler.onConfigurationChanged(new ConfigurationChangedEvent());
 
         Mockito.verifyNoMoreInteractions(this.factory);
         Mockito.verify(this.monitorA).isShutDown();


### PR DESCRIPTION
This changes the dependency injection set up to prevent two SQS queue monitor scheduler instances from being created. Only one instance of the scheduler is now started, so all queues are registered to the same instance. This fixes #7.

The scheduler has been changed to recreate monitors associated with a queue if the queues configuration changes. This fixes #6.

Added code to stop a monitor if credentials are no longer valid, to prevent monitors from retrying to query the queue endlessly. This fixes #5.

Fixed monitors stopping prematurely when a message could not be parsed. This will now log a warning but continue to process remaining messages.