### PR TITLE
Fix sudden stop of queue monitor

### DIFF
--- a/src/main/java/io/relution/jenkins/scmsqs/logging/Log.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/logging/Log.java
@@ -28,19 +28,19 @@ public class Log {
         LOGGER = Logger.getLogger(Log.class.getName());
     }
 
-    private static void write(final Level level, final String message, final Object... args) {
+    private static String format(final String message, final Object... args) {
         final String formatted = String.format(message, args);
         final long id = Thread.currentThread().getId();
+        return String.format("%06X %s", id, formatted);
+    }
 
-        final String msg = String.format("%06X %s", id, formatted);
+    private static void write(final Level level, final String message, final Object... args) {
+        final String msg = format(message, args);
         LOGGER.log(level, msg);
     }
 
     private static void write(final Level level, final Throwable thrown, final String message, final Object... args) {
-        final String formatted = String.format(message, args);
-        final long id = Thread.currentThread().getId();
-
-        final String msg = String.format("%06X %s", id, formatted);
+        final String msg = format(message, args);
         LOGGER.log(level, msg, thrown);
     }
 

--- a/src/main/java/io/relution/jenkins/scmsqs/logging/Log.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/logging/Log.java
@@ -29,12 +29,18 @@ public class Log {
     }
 
     private static void write(final Level level, final String message, final Object... args) {
-        final String msg = String.format(message, args);
+        final String formatted = String.format(message, args);
+        final long id = Thread.currentThread().getId();
+
+        final String msg = String.format("%06X %s", id, formatted);
         LOGGER.log(level, msg);
     }
 
     private static void write(final Level level, final Throwable thrown, final String message, final Object... args) {
-        final String msg = String.format(message, args);
+        final String formatted = String.format(message, args);
+        final long id = Thread.currentThread().getId();
+
+        final String msg = String.format("%06X %s", id, formatted);
         LOGGER.log(level, msg, thrown);
     }
 

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
@@ -61,8 +61,7 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
     private SQSQueueMonitorImpl(final ExecutorService executor,
             final SQSQueue queue,
             final SQSChannel channel,
-            final List<SQSQueueListener> listeners,
-            final boolean isShutDown) {
+            final List<SQSQueueListener> listeners) {
         ThrowIf.isNull(executor, "executor");
         ThrowIf.isNull(channel, "channel");
 
@@ -77,7 +76,7 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
     @Override
     public SQSQueueMonitor clone(final SQSQueue queue, final SQSChannel channel) {
         synchronized (this.listenersLock) {
-            return new SQSQueueMonitorImpl(this.executor, queue, channel, this.listeners, this.isShutDown);
+            return new SQSQueueMonitorImpl(this.executor, queue, channel, this.listeners);
         }
     }
 

--- a/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImpl.java
@@ -124,7 +124,6 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
 
             Log.fine("Start synchronous monitor for %s", this.channel);
             this.processMessages();
-            this.execute();
 
         } catch (final com.amazonaws.services.sqs.model.QueueDoesNotExistException e) {
             Log.warning("Queue %s does not exist, monitor stopped", this.channel);
@@ -142,6 +141,7 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
             if (!this.isRunning.compareAndSet(true, false)) {
                 Log.warning("Monitor for %s already stopped", this.channel);
             }
+            this.execute();
         }
     }
 


### PR DESCRIPTION
This fixes the sudden stop of the queue monitor in some cases.

This issue was visible in the logs by a message pair that said "monitor already started" and "monitor already stopped". After this message pair the monitor stopped working.

This issue occurred when the monitor rescheduled itself and the thread pool executor executed the run method before the previous run completed. In this case the second run would report "already running" before setting "isRunning" to false, which would cause the first run to report "already stopped". Since the second run did not reschedule again the monitor stopped working.

The monitor will now reschedule itself after isRunning has been set to false.